### PR TITLE
Small tweaks per BSch

### DIFF
--- a/src/Form/ManuscriptFilterType.php
+++ b/src/Form/ManuscriptFilterType.php
@@ -54,6 +54,7 @@ class ManuscriptFilterType extends AbstractType {
             'multiple' => true,
             'label' => 'Print Sources',
             'row_attr' => ['class' => 'filter filter_entity filter_printSources'],
+            'query_builder' => $this->sortByLabel(PrintSource::class),
         ]);
         $builder->add('regions', Filters\EntityFilterType::class, [
             'class' => Region::class,

--- a/src/Menu/Builder.php
+++ b/src/Menu/Builder.php
@@ -154,7 +154,7 @@ class Builder implements ContainerAwareInterface {
         $menuItems['people']->addChild('Browse Poem Roles', [
             'route' => 'content_role_index',
         ]);
-        $menuItems['people']->addChild('Browse Manuscript Roles', [
+        $menuItems['people']->addChild('Browse Manuscript Contributions', [
             'route' => 'manuscript_role_index',
         ]);
         $menuItems['poems']->addChild('Browse all Poems', [
@@ -192,7 +192,7 @@ class Builder implements ContainerAwareInterface {
         $menu->addChild('Manuscripts', [
             'route' => 'manuscript_index',
         ]);
-        $menu->addChild('Manuscript Roles', [
+        $menu->addChild('Manuscript Contributions', [
             'route' => 'manuscript_role_index',
         ]);
         $menu->addChild('Periods', [

--- a/src/Repository/ManuscriptRepository.php
+++ b/src/Repository/ManuscriptRepository.php
@@ -66,7 +66,7 @@ class ManuscriptRepository extends ServiceEntityRepository {
 
     public function getSortedQuery($qb, $sort) {
         if ( ! $sort) {
-            return $qb->getQuery();
+            return $qb->orderBy('e.callNumber', 'ASC');
         }
 
         switch ($sort) {

--- a/src/Repository/ManuscriptRepository.php
+++ b/src/Repository/ManuscriptRepository.php
@@ -71,6 +71,7 @@ class ManuscriptRepository extends ServiceEntityRepository {
 
         switch ($sort) {
             case 'title_asc':
+                /*'^(([[:punct:]]|((a|the)\\s))+)' */
                 // Some untitled items have titles, so we have to catch this
                 $qb->orderBy('e.untitled', 'ASC');
                 $qb->addOrderBy('e.title', 'ASC');

--- a/templates/manuscript/partial/sorter.html.twig
+++ b/templates/manuscript/partial/sorter.html.twig
@@ -1,6 +1,6 @@
 {% set sort_opts = {
-    'callNumber_asc': 'Call Number (A-Z)',
-    'callNumber_desc': 'Call Number (Z-A)',
+    'callNumber_asc': 'Archive (A-Z)',
+    'callNumber_desc': 'Archive (Z-A)',
     'title_asc': 'Title (A-Z)',
     'title_desc': 'Title (Z-A)',
     'periods_asc': 'Period (Ascending)',

--- a/templates/manuscript_role/index.html.twig
+++ b/templates/manuscript_role/index.html.twig
@@ -3,7 +3,7 @@
 {% block title %}Manuscript Role List{% endblock %}
 
 {% block pageheader %}
-    <h1>Manuscript Roles</h1>
+    <h1>Manuscript Contributions</h1>
     <p>Roles played by individuals in relation to manuscript miscellanies</p>
     {% include 'partial/count.html.twig' with {'index': manuscriptRoles, 'label': 'manuscript roles'} %}
 {% endblock %}


### PR DESCRIPTION
Per email "MVM Sort & Search feedback," tweaking the following:

* Fixing call number sort to properly use archive / call number by default
* Sorting Print Sources dropdown
* Changing nomenclature 
    * > I’d like some kind of recognition factor between Manuscript Contributors here and the Manuscript Roles table under the People, Coteries, Roles tab. On the latter’s drop-down menu we have Browse Poem Roles and Browse Manuscript Roles. Could Manuscript Roles be renamed as Manuscript Contributions? That would synch with MS Contributors and also with the Contributors tab in a ms. I realize it’s a longer term and then doesn’t quite correlate with Poem Roles, but I think it would help with interpretation of what the search option means, and also what Manuscript Roles/Contributions means. (The description, “Roles played by individuals in relation to ms miscellanies” could remain as is for “Manuscript Contributions”). 